### PR TITLE
Added support for wheel files with local version (pep-0440)

### DIFF
--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -150,7 +150,7 @@ class Package(NamedTuple):
             upload_timestamp: Optional[int] = None,
             uploaded_by: Optional[str] = None,
     ) -> 'Package':
-        if not re.match('[a-zA-Z0-9_\-\.]+$', filename) or '..' in filename:
+        if not re.match('[a-zA-Z0-9_\-\.\+]+$', filename) or '..' in filename:
             raise ValueError(f'Unsafe package name: {filename}')
 
         name, version = guess_name_version_from_filename(filename)

--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -150,7 +150,7 @@ class Package(NamedTuple):
             upload_timestamp: Optional[int] = None,
             uploaded_by: Optional[str] = None,
     ) -> 'Package':
-        if not re.match('[a-zA-Z0-9_\-\.\+]+$', filename) or '..' in filename:
+        if not re.match(r'[a-zA-Z0-9_\-\.\+]+$', filename) or '..' in filename:
             raise ValueError(f'Unsafe package name: {filename}')
 
         name, version = guess_name_version_from_filename(filename)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -104,6 +104,14 @@ def test_package_info_all_info():
     }
 
 
+def test_package_info_wheel_with_local_version():
+    ret = main.Package.create(filename='f-1.0+local-py3-none-any.whl').json_info('/prefix')
+    assert ret == {
+        'filename': 'f-1.0+local-py3-none-any.whl',
+        'url': '/prefix/f-1.0+local-py3-none-any.whl'
+    }
+
+
 def test_package_info_minimal_info():
     ret = main.Package.create(filename='f-1.0.tar.gz').json_info('/prefix')
     assert ret == {'filename': 'f-1.0.tar.gz', 'url': '/prefix/f-1.0.tar.gz'}

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -105,11 +105,8 @@ def test_package_info_all_info():
 
 
 def test_package_info_wheel_with_local_version():
-    ret = main.Package.create(filename='f-1.0+local-py3-none-any.whl').json_info('/prefix')
-    assert ret == {
-        'filename': 'f-1.0+local-py3-none-any.whl',
-        'url': '/prefix/f-1.0+local-py3-none-any.whl'
-    }
+    ret = main.Package.create(filename='f-1.0+local-py3-none-any.whl')
+    assert ret.version == '1.0+local'
 
 
 def test_package_info_minimal_info():


### PR DESCRIPTION
Fixed an issue where wheel files with local version identifiers (eg. f-1.0+local-py3-none-any.whl) were being rejected as having unsafe package names, since '+' was being rejected based on the filename regex in Package.create. '+' is a permitted character in wheel filenames as per PEP-0440 (https://www.python.org/dev/peps/pep-0440/#local-version-identifiers).