### PR TITLE
Tweak a few things to improve performance

### DIFF
--- a/dumb_pypi/templates/package.html
+++ b/dumb_pypi/templates/package.html
@@ -5,12 +5,12 @@
     </head>
     <body>
         <h1>{{package_name}}</h1>
-        <p>Latest version: {{(files|first).version}}</p>
+        <p>Latest version: {{(files|last).version}}</p>
         {% if generate_timestamp %}
             <p>Generated on {{date}}.</p>
         {% endif %}
         <ul>
-            {% for file in files %}
+            {% for file in files|reverse %}
                 <li><a href="{{file.url(packages_url)}}">{{file.filename}}</a> ({{file.info_string}})</li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
At $JOB, I noticed that our dumb-pypi invocations have gotten super slow (32.1 seconds just to run dumb-pypi, not counting the time spent to fetch the package list from S3).

I spent some time with a profiler to try to figure out why -- turns out most of that time was spent sorting packages (particularly, parsing the same package version over and over and over).

I made a few tweaks:

1. `32.1s => 11.0s` from only parsing the version once per package (rather than many thousands of times due to the sort key being constantly recalculated)
2. `11.0s => 9.1s` from using the wheel filename regex rather than instantiating new wheel objects just to grab the name and version
3. `9.1s => 7.2s` after a change to only sort package versions once (rather than twice) per package

Obviously the second two aren't such a big deal, but I don't think they make the code any more complex, so they seem worth keeping.

According to cProfile, the time spent after these patches is roughly evenly split between version parsing, JSON parsing, JSON dumping, and Jinja rendering, which seems about right. IO is actually a pretty small portion of the total time.