### PR TITLE
Downgrade to autopep8==1.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.1
+    rev: v1.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports


### PR DESCRIPTION
1.4.1 is horribly broken: https://github.com/hhatto/autopep8/issues/441

Committed via https://github.com/asottile/all-repos