### PR TITLE
Remove noop `dist: trusty` from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: trusty
 install: pip install coveralls
 script: make test
 python: '3.6'


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos