### PR TITLE
Stop constructing packages twice for no reason

### DIFF
--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -282,7 +282,7 @@ def _create_packages(
             # TODO: this should really be optional; i'd prefer it to fail hard
             print(f'{ex} (skipping package)', file=sys.stderr)
         else:
-            packages[package.name].add(Package.create(**package_info))
+            packages[package.name].add(package)
 
     return packages
 


### PR DESCRIPTION
As far as I can tell this was just an oversight, can't see any reason why we were doing this.