### PR TITLE
factor out distlib

### DIFF
--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -30,7 +30,6 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 
-import distlib.wheel
 import jinja2
 import packaging.utils
 import packaging.version
@@ -50,11 +49,8 @@ def guess_name_version_from_filename(
         filename: str,
 ) -> Tuple[str, Optional[str]]:
     if filename.endswith('.whl'):
-        m = distlib.wheel.FILENAME_RE.match(filename)
-        if m is not None:
-            return m.group('nm'), m.group('vn')
-        else:
-            raise ValueError(f'Invalid package name: {filename}')
+        name, version, _, _ = packaging.utils.parse_wheel_filename(filename)
+        return name, str(version)
     else:
         # These don't have a well-defined format like wheels do, so they are
         # sort of "best effort", with lots of tests to back them up.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,8 @@ classifiers =
 [options]
 packages = dumb_pypi
 install_requires =
-    distlib
     jinja2
-    packaging
+    packaging>=20.9
 python_requires = >=3.7
 
 [options.entry_points]

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,9 +7,9 @@ from dumb_pypi import main
 
 @pytest.mark.parametrize(('filename', 'name', 'version'), (
     # wheels
-    ('dumb_init-1.2.0-py2.py3-none-manylinux1_x86_64.whl', 'dumb_init', '1.2.0'),
+    ('dumb_init-1.2.0-py2.py3-none-manylinux1_x86_64.whl', 'dumb-init', '1.2.0'),
     ('ocflib-2016.12.10.1.48-py2.py3-none-any.whl', 'ocflib', '2016.12.10.1.48'),
-    ('aspy.yaml-0.2.2-py2.py3-none-any.whl', 'aspy.yaml', '0.2.2'),
+    ('aspy.yaml-0.2.2-py2.py3-none-any.whl', 'aspy-yaml', '0.2.2'),
     (
         'numpy-1.11.1rc1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl',  # noqa
         'numpy',
@@ -58,7 +58,6 @@ def test_guess_name_version_from_filename_only_name(filename, name, version):
     'lol',
     'lol-sup',
     '-20160920.193125.zip',
-    'playlyfe-0.1.1-2.7.6-none-any.whl',  # 2.7.6 is not a valid python tag
 ))
 def test_guess_name_version_from_filename_invalid(filename):
     with pytest.raises(ValueError):


### PR DESCRIPTION
distlib is ~sorta deprecated and `packaging` is the way forward.  the validation of tags is slightly worse in `packaging` so I deleted the one test that was failing afterwards