### PR TITLE
Add option to disable per-release JSON metadata

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -463,6 +463,19 @@ def test_build_repo_no_generate_timestamp(tmpdir):
         assert 'Generated on' not in tmpdir.join(p).read()
 
 
+def test_build_repo_no_per_release_json(tmp_path):
+    package_list = tmp_path / 'package-list'
+    package_list.write_text('pkg-1.0.tar.gz\n')
+    main.main((
+        '--package-list', str(package_list),
+        '--output-dir', str(tmp_path),
+        '--packages-url', '../../pool',
+        '--no-per-release-json',
+    ))
+    metadata_path = tmp_path / 'pypi' / 'pkg'
+    assert set(metadata_path.iterdir()) == {metadata_path / 'json'}
+
+
 def test_build_repo_even_with_bad_package_names(tmpdir):
     package_list = tmpdir.join('package-list')
     package_list.write('\n'.join((


### PR DESCRIPTION
I originally added this option for Poetry since it uses it to fetch metadata, but it turns out it actually hard-codes that path for public PyPI only and won't let you enable it for other index servers at all.

This extra metadata has started to cause us some problems internally because it's just so many files to write and manage. For example, calling `docker rm` on the container we run dumb-pypi in usually times out because it takes too long to clean up all the tiny files.