### PR TITLE
Allow wheels with invalid PEP440 versions again

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -22,14 +22,17 @@ def test_natural_key(s, expected):
 
 @pytest.mark.parametrize(('filename', 'name', 'version'), (
     # wheels
-    ('dumb_init-1.2.0-py2.py3-none-manylinux1_x86_64.whl', 'dumb-init', '1.2.0'),
+    ('dumb_init-1.2.0-py2.py3-none-manylinux1_x86_64.whl', 'dumb_init', '1.2.0'),
     ('ocflib-2016.12.10.1.48-py2.py3-none-any.whl', 'ocflib', '2016.12.10.1.48'),
-    ('aspy.yaml-0.2.2-py2.py3-none-any.whl', 'aspy-yaml', '0.2.2'),
+    ('aspy.yaml-0.2.2-py2.py3-none-any.whl', 'aspy.yaml', '0.2.2'),
     (
         'numpy-1.11.1rc1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl',  # noqa
         'numpy',
         '1.11.1rc1',
     ),
+    # Invalid PEP440 version, but still intentionally allowed for compatibility
+    # with early releases of dumb-pypi until our next major version.
+    ('somepackage-1.2.3.4.post5.post2-py3-none-any.whl', 'somepackage', '1.2.3.4.post5.post2'),
 
     # other stuff
     ('aspy.yaml.zip', 'aspy.yaml', None),
@@ -73,6 +76,7 @@ def test_guess_name_version_from_filename_only_name(filename, name, version):
     'lol',
     'lol-sup',
     '-20160920.193125.zip',
+    'playlyfe-0.1.1-2.7.6-none-any.whl',  # 2.7.6 is not a valid python tag
 ))
 def test_guess_name_version_from_filename_invalid(filename):
     with pytest.raises(ValueError):


### PR DESCRIPTION
The switch in #91 resulted in wheels with invalid PEP440 versions being rejected. This is IMO a reasonable change but we should probably consider it a major version / breaking change since it causes previously working installations (e.g. at my company) to suddenly break things for consumers in a surprising and hard-to-fix way.

My motivation behind making a release that allows these (rather than just accepting this as a breaking change going forward) is that we'd really like a usable version of dumb-pypi that contains #97 since it is causing us issues.