### PR TITLE
fix tags trigger for github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches: [master]
-    tags:
+    tags: '*'
   pull_request:
 jobs:
   tox:


### PR DESCRIPTION
the old syntax worked for azure pipelines but not GHA

Committed via https://github.com/asottile/all-repos