### PR TITLE
Use timezone-aware UTC datetimes

### DIFF
--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -23,7 +23,7 @@ import tempfile
 from collections.abc import Generator
 from collections.abc import Iterator
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from typing import IO
 from typing import NamedTuple
@@ -132,7 +132,7 @@ class Package(NamedTuple):
     @property
     def formatted_upload_time(self) -> str:
         assert self.upload_timestamp is not None
-        dt = datetime.utcfromtimestamp(self.upload_timestamp)
+        dt = datetime.fromtimestamp(self.upload_timestamp, timezone.utc)
         return _format_datetime(dt)
 
     @property
@@ -305,7 +305,7 @@ def build_repo(
 ) -> None:
     simple = os.path.join(settings.output_dir, 'simple')
     pypi = os.path.join(settings.output_dir, 'pypi')
-    current_date = _format_datetime(datetime.utcnow())
+    current_date = _format_datetime(datetime.now(timezone.utc))
 
     jinja_env = jinja2.Environment(
         loader=jinja2.PackageLoader('dumb_pypi', 'templates'),

--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -23,7 +23,8 @@ import tempfile
 from collections.abc import Generator
 from collections.abc import Iterator
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 from typing import IO
 from typing import NamedTuple


### PR DESCRIPTION
## Summary
- Replace deprecated UTC datetime helpers with timezone-aware UTC alternatives.
- Preserve the existing generated timestamp and upload time string format.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `rg --line-number datetime\.utcnow|datetime\.utcfromtimestamp|\.utcnow\(|\.utcfromtimestamp\( dumb_pypi tests` returned no matches
- Not run locally

Closes #171