### PR TITLE
Support integer versions in sdist filenames

### DIFF
--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -81,6 +81,14 @@ def guess_name_version_from_filename(
                     if '.' in part and re.search('[0-9]', part):
                         name, version = '-'.join(parts[0:i]), '-'.join(parts[i:])
 
+                if version is None:
+                    try:
+                        version = str(packaging.utils.parse_sdist_filename(filename)[1])
+                    except packaging.utils.InvalidSdistFilename:
+                        pass
+                    else:
+                        name = name.rsplit('-', 1)[0]
+
         # possible with poorly-named files
         if len(name) <= 0:
             raise ValueError(f'Invalid package name: {filename}')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -37,7 +37,8 @@ def test_natural_key(s, expected):
 
     # other stuff
     ('aspy.yaml.zip', 'aspy.yaml', None),
-    ('ocflib-3-4.tar.gz', 'ocflib-3-4', None),
+    ('ocflib-3-4.tar.gz', 'ocflib-3', '4'),
+    ('systemd-python-234.tar.gz', 'systemd-python', '234'),
     ('aspy.yaml-0.2.1.tar.gz', 'aspy.yaml', '0.2.1'),
     ('numpy-1.11.0rc1.tar.gz', 'numpy', '1.11.0rc1'),
     ('pandas-0.2beta.tar.gz', 'pandas', '0.2beta'),


### PR DESCRIPTION
Summary:
- fall back to packaging.utils.parse_sdist_filename when the legacy sdist heuristic leaves the version unknown
- parse PEP 440 integer versions in sdist names like systemd-python-234.tar.gz
- update filename parsing coverage for the integer-version ambiguity

Validation:
- Not run locally.

Closes #39