### PR TITLE
Support URLs in package lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ ocflib-2016.10.31.0.40-py2.py3-none-any.whl
 pre_commit-0.9.2.tar.gz
 ```
 
+The plain-text package list can also contain HTTP(S) package URLs. In that
+case, dumb-pypi uses the last path component as the package filename and links
+to the URL directly in the generated index.
+
 You should also know a URL to access these packages (if you serve them from the
 same host as the index, it can be a relative URL). For example, it might be
 `https://my-pypi-packages.s3.amazonaws.com/` or `../../pool/`.
@@ -114,6 +118,7 @@ object per line, like this:
 | Key                  | Required? | Description |
 | -------------------- | --------- | ----------- |
 | `filename`           | Yes       | Name of the file |
+| `download_url`       | No        | Absolute URL to link directly instead of building the URL from `--packages-url` |
 | `hash`               | No        | Hash of the file in the format `<hashalgo>=<hashvalue>` |
 | `requires_python`    | No        | Python requirement string for the package ([PEP345](https://peps.python.org/pep-0345/#requires-python)) |
 | `core_metadata`      | No        | Either string `"true"` or a string in the format `<hashalgo>=<hashvalue>` to indicate metadata is available for this file by appending `.metadata` to the file URL ([PEP658](https://peps.python.org/pep-0658/), [PEP714](https://peps.python.org/pep-0714/)) |

--- a/dumb_pypi/main.py
+++ b/dumb_pypi/main.py
@@ -17,9 +17,11 @@ import itertools
 import json
 import math
 import os.path
+import posixpath
 import re
 import sys
 import tempfile
+import urllib.parse
 from collections.abc import Generator
 from collections.abc import Iterator
 from collections.abc import Sequence
@@ -100,6 +102,7 @@ def _natural_key(s: str) -> tuple[int | str, ...]:
 
 class Package(NamedTuple):
     filename: str
+    download_url: str | None
     name: str
     version: str | None
     parsed_version: packaging.version.Version
@@ -151,8 +154,12 @@ class Package(NamedTuple):
         return info
 
     def url(self, base_url: str, *, include_hash: bool = True) -> str:
-        hash_part = f'#{self.hash}' if self.hash and include_hash else ''
-        return f'{base_url.rstrip("/")}/{self.filename}{hash_part}'
+        url = self.download_url if self.download_url is not None else f'{base_url.rstrip("/")}/{self.filename}'
+        if self.hash and include_hash:
+            parts = urllib.parse.urlsplit(url)
+            if not parts.fragment:
+                url = urllib.parse.urlunsplit(parts._replace(fragment=self.hash))
+        return url
 
     @property
     def packagetype(self) -> str:
@@ -192,6 +199,7 @@ class Package(NamedTuple):
             cls,
             *,
             filename: str,
+            download_url: str | None = None,
             hash: str | None = None,
             requires_dist: Sequence[str] | None = None,
             requires_python: str | None = None,
@@ -202,10 +210,15 @@ class Package(NamedTuple):
     ) -> Package:
         if not re.match(r'[a-zA-Z0-9_\-\.\+]+$', filename) or '..' in filename:
             raise ValueError(f'Unsafe package name: {filename}')
+        if download_url is not None:
+            parsed_download_url = urllib.parse.urlsplit(download_url)
+            if parsed_download_url.scheme not in {'http', 'https'} or not parsed_download_url.netloc:
+                raise ValueError(f'Unsafe package URL: {download_url}')
 
         name, version = guess_name_version_from_filename(filename)
         return cls(
             filename=filename,
+            download_url=download_url,
             name=packaging.utils.canonicalize_name(name),
             version=version,
             parsed_version=packaging.version.parse(version or '0'),
@@ -441,8 +454,17 @@ def _create_packages(
     return packages
 
 
+def _package_info_from_line(line: str) -> dict[str, Any]:
+    parsed = urllib.parse.urlsplit(line)
+    if parsed.scheme in {'http', 'https'} and parsed.netloc:
+        filename = urllib.parse.unquote(posixpath.basename(parsed.path))
+        return {'filename': filename, 'download_url': line}
+    else:
+        return {'filename': line}
+
+
 def package_list(path: str) -> dict[str, set[Package]]:
-    return _create_packages({'filename': line} for line in _lines_from_path(path))
+    return _create_packages(_package_info_from_line(line) for line in _lines_from_path(path))
 
 
 def package_list_json(path: str) -> dict[str, set[Package]]:

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -98,6 +98,15 @@ def test_package_invalid(filename):
         main.Package.create(filename=filename)
 
 
+@pytest.mark.parametrize('download_url', (
+    'relative/f-1.0.tar.gz',
+    'javascript://example.com/f-1.0.tar.gz',
+))
+def test_package_invalid_download_url(download_url):
+    with pytest.raises(ValueError):
+        main.Package.create(filename='f-1.0.tar.gz', download_url=download_url)
+
+
 def test_package_url_no_hash():
     package = main.Package.create(filename='f.tar.gz')
     assert package.url('/prefix') == '/prefix/f.tar.gz'
@@ -106,6 +115,23 @@ def test_package_url_no_hash():
 def test_package_url_with_hash():
     package = main.Package.create(filename='f.tar.gz', hash='sha256=badf00d')
     assert package.url('/prefix') == '/prefix/f.tar.gz#sha256=badf00d'
+
+
+def test_package_url_with_download_url():
+    url = 'https://github.com/acme/packages/releases/download/v1.0/f-1.0.tar.gz'
+    package = main.Package.create(filename='f-1.0.tar.gz', download_url=url)
+    assert package.url('/prefix') == url
+
+
+def test_package_url_with_download_url_and_hash():
+    url = 'https://github.com/acme/packages/releases/download/v1.0/f-1.0.tar.gz'
+    package = main.Package.create(
+        filename='f-1.0.tar.gz',
+        download_url=url,
+        hash='sha256=badf00d',
+    )
+    assert package.url('/prefix') == f'{url}#sha256=badf00d'
+    assert package.url('/prefix', include_hash=False) == url
 
 
 @pytest.mark.parametrize(
@@ -161,6 +187,15 @@ def test_package_info_minimal_info():
     }
 
 
+def test_package_info_with_download_url():
+    url = 'https://github.com/acme/packages/releases/download/v1.0/f-1.0.tar.gz'
+    ret = main.Package.create(
+        filename='f-1.0.tar.gz',
+        download_url=url,
+    ).json_info('/prefix')
+    assert ret['url'] == url
+
+
 def test_input_json_all_info():
     package = main.Package.create(
         filename='f-1.0.tar.gz',
@@ -189,6 +224,16 @@ def test_input_json_all_info():
 def test_input_json_minimal():
     package = main.Package.create(filename='f-1.0.tar.gz')
     assert package.input_json() == {'filename': 'f-1.0.tar.gz'}
+    assert main.Package.create(**package.input_json()) == package
+
+
+def test_input_json_with_download_url():
+    url = 'https://github.com/acme/packages/releases/download/v1.0/f-1.0.tar.gz'
+    package = main.Package.create(filename='f-1.0.tar.gz', download_url=url)
+    assert package.input_json() == {
+        'filename': 'f-1.0.tar.gz',
+        'download_url': url,
+    }
     assert main.Package.create(**package.input_json()) == package
 
 
@@ -309,6 +354,27 @@ def test_build_repo_smoke_test(tmpdir):
     assert tmpdir.join('simple', 'ocflib', 'index.html').check(file=True)
     assert tmpdir.join('pypi', 'ocflib', 'json').check(file=True)
     assert tmpdir.join('pypi', 'ocflib', '2016.12.10.1.48', 'json').check(file=True)
+
+
+def test_build_repo_with_package_list_urls(tmpdir):
+    url = 'https://github.com/acme/packages/releases/download/v1.0/pkg-1.0.tar.gz'
+    package_list = tmpdir.join('package-list')
+    package_list.write(f'{url}\n')
+    main.main((
+        '--package-list', package_list.strpath,
+        '--output-dir', tmpdir.strpath,
+        '--packages-url', '../../pool/',
+        '--no-generate-timestamp',
+    ))
+
+    package_page = tmpdir.join('simple', 'pkg', 'index.html').read()
+    assert f'href="{url}"' in package_page
+
+    with tmpdir.join('packages.json').open() as f:
+        assert json.loads(f.readline()) == {
+            'filename': 'pkg-1.0.tar.gz',
+            'download_url': url,
+        }
 
 
 def _write_json_package_list(path, packages):


### PR DESCRIPTION
Summary:
- accept HTTP(S) URLs in plain-text package lists by extracting package filenames from URL paths
- preserve explicit download URLs in generated package links and package metadata
- document the optional `download_url` JSON package-list field

Validation:
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
- Not run locally.

Closes #163